### PR TITLE
make CDT respect segments

### DIFF
--- a/adaptmesh/initial.py
+++ b/adaptmesh/initial.py
@@ -44,7 +44,7 @@ def cdt(corner_points=None, **params):
                 mpltPath.Path([[point[0], point[1]] for point in hole])
             )
 
-    dt = triangulate(points, segments)
+    dt = triangulate(points, segments=segments)
 
     # find triangles inside the polygon
     p, t = [], []

--- a/adaptmesh/tri/delaunay.py
+++ b/adaptmesh/tri/delaunay.py
@@ -1103,10 +1103,7 @@ class ConstraintInserter(object):
                 self.triangulation.vertices[segment[0]],
                 self.triangulation.vertices[segment[1]],
             )
-            try:
-                self.insert_constraint(p, q)
-            except Exception as err:
-                print(err)
+            self.insert_constraint(p, q)
         self.remove_empty_triangles()
 
     def remove_empty_triangles(self):
@@ -1121,7 +1118,7 @@ class ConstraintInserter(object):
             ),
             self.triangulation.triangles,
         )
-        self.triangulation.triangles = new
+        self.triangulation.triangles = list(new)
 
     def insert_constraint(self, P, Q):
         """Insert constraint into triangulation.
@@ -1223,7 +1220,7 @@ class CavityCDT(object):
         # Initialization for the algorithm
         m = len(self.vertices)
         # Make random permutation of point indices
-        self.pi = range(1, m - 1)
+        self.pi = list(range(1, m - 1))
         # Randomize processing order
         shuffle(self.pi)
         # Link all vertices in a circular list that

--- a/tests/test_nonconvex.py
+++ b/tests/test_nonconvex.py
@@ -1,0 +1,15 @@
+from adaptmesh import initial
+
+
+def test_nonconvex():
+    pts = [(0.0, 0.0),
+           (1.1, 0.0),
+           (1.2, 0.5),
+           (0.7, 0.6),
+           (2.0, 1.0),
+           (1.0, 2.0),
+           (0.5, 1.5),]
+
+    m = initial.cdt(pts)
+    boundary_pts = set(map(tuple, m.p.T[m.boundary_nodes()]))
+    assert boundary_pts == set(pts)


### PR DESCRIPTION
The initial CDT step did not respect the segments from the input polygon. This is apparent in the non-convex example you provide, where the point (0.7, 0.6) is actually missing in the mesh.

There were three issues:
1) `tri.triangulate(points, infos=None, segments=None)`, expects segments as either the third positional or as a named argument. However, in `initial.cdt` this is violated by calling `triangulate(points, segments)`. A fix is to either call `triangulate(points, None, segments)` or `triangulate(points, segments=segments)`. I propose the latter for clarity.

2) In `tri.delaunay.CavityCDT._preprocess` there was an attempt to `shuffle` the `range` generator, but `shuffle` expects a `list`. Although this raises an error, this was masked by the `try`-`except` arorund the `self.insert_constraint(p, q)` in `tri.delaunay.ConstraintInserter.insert`. I suggest creating a `list` from the generator before shuffling and removing the error suppression for a more predictable behaviour.

3) While removing the empty triangles in `tri.delaunay.ConstraintInserter.remove_empty_triangles`, the result is a generator which is assigned to `self.triangulation.triangles`. This generator is then exhausted in the subsequent call to `FiniteEdgeIterator` so that later the triangulation is just empty. Again, I would just simply make this a list inside the `remove_empty_triangles`.


On top of that I also added a small test in `test_nonconvex.py` to verify that the boundary nodes of the initial mesh are exactly the same as for the input polygon.